### PR TITLE
Normalize repo name for Docker tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,11 +27,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Normalize repository name
+        run: echo "REPO=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ env.REPO }}:latest
+            ghcr.io/${{ env.REPO }}:${{ github.sha }}


### PR DESCRIPTION
## Summary
- ensure GHCR tags use lowercase repository by normalizing `GITHUB_REPOSITORY`

## Testing
- `python -m pytest`
- `yamllint .github/workflows/docker.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689efa344d84832d895874e3f7dd1e45