### PR TITLE
Fix Docker build by removing uWSGI dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,6 @@ tensorflow-io-gcs-filesystem
 termcolor
 typing_extensions
 urllib3
-uWSGI
 Werkzeug
 wrapt
 zipp


### PR DESCRIPTION
## Summary
- drop uWSGI from requirements to prevent compilation failures during image build

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689f1250ccac832d88b51b64c9226fad