### PR TITLE
feat: support anesthesia user creation

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -666,6 +666,9 @@ def create_scanners():
     is_viewer = bool(loaded['is_viewer'])
     is_ot_scanner = bool(loaded['is_ot_scanner'])
     is_ot_viewer = bool(loaded['is_ot_viewer'])
+    # Optional anesthesia roles
+    is_anesthesia_scanner = bool(loaded.get('is_anesthesia_scanner', False))
+    is_anesthesia_viewer = bool(loaded.get('is_anesthesia_viewer', False))
     is_admin = False
     email = str(loaded['email'])
     is_active = True
@@ -686,6 +689,8 @@ def create_scanners():
         "is_viewer": is_viewer,
         "is_ot_scanner": is_ot_scanner,
         "is_ot_viewer": is_ot_viewer,
+        "is_anesthesia_scanner": is_anesthesia_scanner,
+        "is_anesthesia_viewer": is_anesthesia_viewer,
         "last_login": last_login,
         "last_logout": last_logout,
         "password_changed": pass_changed,


### PR DESCRIPTION
## Summary
- allow create_scanners endpoint to optionally mark users as anesthesia scanner/viewer

## Testing
- `python -m py_compile pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68a402827210832d8af8a8a5a327230c