### PR TITLE
Add Anesthesia Documents class to count-based API

### DIFF
--- a/Mongo_APIS.py
+++ b/Mongo_APIS.py
@@ -649,6 +649,7 @@ def image_count_with_class_names(filter_criteria):
             {"name": "Maternity Notes", "id": 8},
             {"name": "PEADS History", "id": 12},
             {"name": "Personalized Document", "id": 14},
+            {"name": "Anesthesia Documents", "id": 16},
             {"name": "Unclassified", "id": 15}
         ]
         print("Defined class details (expected class IDs and names):")


### PR DESCRIPTION
## Summary
- include class 16, "Anesthesia Documents," in Mongo image count API output

## Testing
- `python -m py_compile Mongo_APIS.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a42990d914832dad9f9bbac90afd4a