### PR TITLE
Fix JSON serialization of IPD admission dates

### DIFF
--- a/oracle_apis.py
+++ b/oracle_apis.py
@@ -170,9 +170,19 @@ def ipd_patient_details_dates_only(m):
     """.format(mr)
 
     for row in cursor.execute(query):
+        # ``fld_dat_adm_date`` is returned as a ``datetime`` object by the
+        # database driver.  Flask's JSON encoder cannot directly serialise
+        # ``datetime`` objects which leads to ``TypeError: Object of type
+        # datetime is not JSON serializable`` when the data is returned from
+        # the API.  Convert the value to an ISO formatted string so the result
+        # can be safely encoded as JSON.
+        admission_date = row[1]
+        if hasattr(admission_date, "isoformat"):
+            admission_date = admission_date.isoformat()
+
         query_result = {
             'admission_ID': row[0],
-            'admission_date': row[1]
+            'admission_date': admission_date
         }
         admission_details.append(query_result)
 


### PR DESCRIPTION
## Summary
- Convert Oracle admission dates to ISO strings before returning `/ipd/all_dates` response to avoid JSON serialization errors

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aea0ed2c48832d96473062b48d88c3